### PR TITLE
iOS Fix compiling with swift >= 4.2 & Fix #3

### DIFF
--- a/android/src/main/java/alihoseinpoor/com/open_settings/OpenSettingsPlugin.java
+++ b/android/src/main/java/alihoseinpoor/com/open_settings/OpenSettingsPlugin.java
@@ -24,8 +24,6 @@ public class OpenSettingsPlugin implements MethodCallHandler {
     public void onMethodCall(MethodCall call, Result result) {
         String setting = (String) call.arguments;
         String target;
-        System.out.println("sssssssssssssss");
-
         if (call.method.equals("openSettings")) {
             switch (setting) {
                 case "wifi":

--- a/ios/Classes/SwiftOpenSettingPlugin.swift
+++ b/ios/Classes/SwiftOpenSettingPlugin.swift
@@ -11,10 +11,15 @@ public class SwiftOpenSettingPlugin: NSObject, FlutterPlugin {
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         switch call.method {
         case "openSettings":
-            if let url = URL(string: UIApplicationOpenSettingsURLString) {
-                if (UIApplication.shared.canOpenURL(url)) {
+            #if swift(>=4.2)
+            let url = URL(string: UIApplication.openSettingsURLString)
+            #else
+            let url = URL(string: UIApplicationOpenSettingsURLString)
+            #endif
+            if(url != nil){
+                if (UIApplication.shared.canOpenURL(url!)) {
                     if #available(iOS 10.0, *) {
-                        UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                        UIApplication.shared.open(url!, options: [:], completionHandler: nil)
                     }
                     result(nil)
                 }


### PR DESCRIPTION
On iOS function `UIApplicationOpenSettingsURLString` was obsoleted in Swift 4.2 and removed in Swift 5.
This PR fixes this by using  function `UIApplicationOpenSettingsURLString` when compiling plugin with Swift < 4.2 and using function `UIApplication.openSettingsURLString` on Swift >= 4.2.

Fix #3 