### PR TITLE
Upgrade UIApplicationOpenSettingsURLString the new version

### DIFF
--- a/ios/Classes/SwiftOpenSettingsPlugin.swift
+++ b/ios/Classes/SwiftOpenSettingsPlugin.swift
@@ -11,7 +11,7 @@ public class SwiftOpenSettingsPlugin: NSObject, FlutterPlugin {
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
           switch call.method {
           case "openSettings":
-              if let url = URL(string: UIApplicationOpenSettingsURLString) {
+            if let url = URL(string: UIApplication.openSettingsURLString) {
                   if (UIApplication.shared.canOpenURL(url)) {
                       if #available(iOS 10.0, *) {
                           UIApplication.shared.open(url, options: [:], completionHandler: nil)


### PR DESCRIPTION
Build error on new versions:
```
Error output from Xcode build:
↳
    ** BUILD FAILED **


Xcode's output:
↳
    Command CompileSwift failed with a nonzero exit code
    Command CompileSwift failed with a nonzero exit code
    /Users/runner/hostedtoolcache/flutter/2.0.4-stable/x64/.pub-cache/hosted/pub.dartlang.org/open_settings-2.0.1/ios/Classes/SwiftOpenSettingsPlugin.swift:14:40: error: 'UIApplicationOpenSettingsURLString' has been renamed to 'UIApplication.openSettingsURLString'
                  if let url = URL(string: UIApplicationOpenSettingsURLString) {
                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                           UIApplication.openSettingsURLString
    UIKit.UIApplicationOpenSettingsURLString:3:12: note: 'UIApplicationOpenSettingsURLString' was obsoleted in Swift 4.2
    public let UIApplicationOpenSettingsURLString: String
               ^
    note: Using new build system
    note: Building targets in parallel
    note: Planning build
    note: Constructing build description

Encountered error while building for device.
Error: Process completed with exit code 1.
```